### PR TITLE
feat: Convert from custom resource cdk framework to crhelper package

### DIFF
--- a/API.md
+++ b/API.md
@@ -1824,7 +1824,7 @@ the lambda function code from S3 or some other location because
 the CDK cant upload the local code to the correct asset location
 for the StackSet target accounts.
 
-You can use the included `AccessKeyFunctionCodeCache` class to
+You can use the included `AzIdToNameMappingFunctionCodeCache` class to
 cache the lambda function code in S3 and create a cross
 account access policy to allow the StackSet target accounts
 to access the code.

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,0 +1,1 @@
+crhelper

--- a/test/__snapshots__/vpc.test.ts.snap
+++ b/test/__snapshots__/vpc.test.ts.snap
@@ -106,7 +106,7 @@ Object {
       "Properties": Object {
         "ServiceToken": Object {
           "Fn::GetAtt": Array [
-            "AzIdToNameMappingproviderframeworkonEventBFEE6465",
+            "AzIdToNameMappinghandler3666E550",
             "Arn",
           ],
         },
@@ -119,132 +119,6 @@ Object {
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
-    },
-    "AzIdToNameMappingproviderframeworkonEventBFEE6465": Object {
-      "DependsOn": Array [
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
-      ],
-      "Properties": Object {
-        "Code": Any<Object>,
-        "Description": "AWS CDK resource provider framework - onEvent (TestStack/AzIdToNameMapping/provider)",
-        "Environment": Object {
-          "Variables": Object {
-            "USER_ON_EVENT_FUNCTION_ARN": Object {
-              "Fn::GetAtt": Array [
-                "AzIdToNameMappinghandler3666E550",
-                "Arn",
-              ],
-            },
-          },
-        },
-        "Handler": "framework.onEvent",
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs14.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D": Object {
-      "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-              },
-            ],
-          ],
-        },
-        "RetentionInDays": 30,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::LogRetention",
-    },
-    "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "lambda:InvokeFunction",
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "AzIdToNameMappinghandler3666E550",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "AzIdToNameMappinghandler3666E550",
-                          "Arn",
-                        ],
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "Roles": Array [
-          Object {
-            "Ref": "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": Object {
       "DependsOn": Array [
@@ -326,10 +200,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "CidrBlock": "10.0.0.0/16",
@@ -352,10 +222,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "Tags": Array [
@@ -374,10 +240,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "DestinationCidrBlock": "0.0.0.0/0",
@@ -397,10 +259,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "RouteTableId": Object {
@@ -419,10 +277,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "Tags": Array [
@@ -444,10 +298,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "AvailabilityZone": Object {
@@ -482,10 +332,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "DestinationCidrBlock": "0.0.0.0/0",
@@ -505,10 +351,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "Tags": Array [
@@ -530,10 +372,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "RouteTableId": Object {
@@ -552,10 +390,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "AvailabilityZone": Object {
@@ -590,10 +424,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
         "vpcVPCGW7984C166",
       ],
       "Properties": Object {
@@ -614,10 +444,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "Domain": "vpc",
@@ -637,10 +463,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
         "vpcPublicSubnet1DefaultRoute10708846",
         "vpcPublicSubnet1RouteTableAssociation5D3F4579",
       ],
@@ -670,10 +492,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "Tags": Array [
@@ -695,10 +513,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "RouteTableId": Object {
@@ -717,10 +531,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "AvailabilityZone": Object {
@@ -755,10 +565,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
         "vpcVPCGW7984C166",
       ],
       "Properties": Object {
@@ -779,10 +585,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "Domain": "vpc",
@@ -802,10 +604,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
         "vpcPublicSubnet2DefaultRouteA1EC0F60",
         "vpcPublicSubnet2RouteTableAssociation21F81B59",
       ],
@@ -835,10 +633,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "RouteTableId": Object {
@@ -857,10 +651,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "Tags": Array [
@@ -882,10 +672,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "AvailabilityZone": Object {
@@ -920,10 +706,6 @@ Object {
         "AzIdToNameMappinghandlerPolicyBA4D5D94",
         "AzIdToNameMappinghandlerRole0E94DF36",
         "AzIdToNameMappingmappingFF3EB1A2",
-        "AzIdToNameMappingproviderframeworkonEventLogRetention3F7CD54D",
-        "AzIdToNameMappingproviderframeworkonEventBFEE6465",
-        "AzIdToNameMappingproviderframeworkonEventServiceRoleDefaultPolicyDF224E6A",
-        "AzIdToNameMappingproviderframeworkonEventServiceRole07035C5C",
       ],
       "Properties": Object {
         "InternetGatewayId": Object {


### PR DESCRIPTION
This makes it easier/possible to deploy this function using stacksets by simply referencing the lambda code and not needing to worry about the underlying custom resource mini framework resources