### PR TITLE
fix: Lambda function fails because crhelper is missing

### DIFF
--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,1 +1,1 @@
-crhelper
+crhelper==2.0.11

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,9 +101,22 @@ export class AzIdToNameMapping extends Construct {
       ],
     });
 
+    const bundlingCmds = [
+      'mkdir -p /asset-output',
+      'pip install -r /asset-input/requirements.txt -t /asset-output',
+      'cp index.py /asset-output/index.py',
+    ];
+
     const onEventHandler = new lambda.Function(this, 'handler', {
       runtime: lambda.Runtime.PYTHON_3_8,
-      code: props.lambdaCode ?? lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
+      code: props.lambdaCode ?? lambda.Code.fromAsset(path.join(__dirname, '../lambda'), {
+        bundling: {
+          image: lambda.Runtime.PYTHON_3_9.bundlingImage,
+          command: [
+            'bash', '-c', bundlingCmds.join(' && '),
+          ],
+        },
+      }),
       handler: 'index.handler',
       description: 'Stores VPC mappings into parameter store',
       timeout: Duration.seconds(5),


### PR DESCRIPTION
DEVOPS-355 #comment This was caused by the change to support StackSets which was the only context we were currently using internally. This added the crhelper dependency. We need to make sure this dependency is bundled in all contexts but we only covered the cached code context.